### PR TITLE
Fix handling of patent numbers starting with H0

### DIFF
--- a/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
+++ b/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
@@ -197,8 +197,8 @@ def parse_patents(fd,fd2):
                 for line in patent:
                     if line.startswith("WKU"):
                         patnum = re.search('WKU\s+(.*?)$',line).group(1)
-                        patnum = patnum[:8] # Remove check digit
-                        updnum = re.sub('^H0','H',patnum)
+                        updnum = patnum[:8] # Remove check digit
+                        updnum = re.sub('^H0','H',updnum)
                         updnum = re.sub('^RE0','RE',updnum)
                         updnum = re.sub('^PP0','PP',updnum)
                         updnum = re.sub('^PP0','PP',updnum)

--- a/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
+++ b/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
@@ -200,8 +200,7 @@ def parse_patents(fd,fd2):
                         updnum = patnum[:8] # Remove check digit
                         updnum = re.sub('^H0','H',updnum)
                         updnum = re.sub('^RE0','RE',updnum)
-                        updnum = re.sub('^PP0','PP',updnum)
-                        updnum = re.sub('^PP0','PP',updnum)
+                        updnum = re.sub('^PP00?','PP',updnum)
                         updnum = re.sub('^D0', 'D', updnum)
                         updnum = re.sub('^T0', 'T', updnum)
                         if len(patnum) > 7 and patnum.startswith('0'):

--- a/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
+++ b/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
@@ -197,12 +197,13 @@ def parse_patents(fd,fd2):
                 for line in patent:
                     if line.startswith("WKU"):
                         patnum = re.search('WKU\s+(.*?)$',line).group(1)
-                        updnum = re.sub('^H0','H',patnum)[:8]
-                        updnum = re.sub('^RE0','RE',updnum)[:8]
-                        updnum = re.sub('^PP0','PP',updnum)[:8]
-                        updnum = re.sub('^PP0','PP',updnum)[:8]
-                        updnum = re.sub('^D0', 'D', updnum)[:8]
-                        updnum = re.sub('^T0', 'T', updnum)[:8]
+                        patnum = patnum[:8] # Remove check digit
+                        updnum = re.sub('^H0','H',patnum)
+                        updnum = re.sub('^RE0','RE',updnum)
+                        updnum = re.sub('^PP0','PP',updnum)
+                        updnum = re.sub('^PP0','PP',updnum)
+                        updnum = re.sub('^D0', 'D', updnum)
+                        updnum = re.sub('^T0', 'T', updnum)
                         if len(patnum) > 7 and patnum.startswith('0'):
                             updnum = patnum[1:8]
                         #data['patnum'] = updnum

--- a/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
+++ b/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_1976_2001.py
@@ -197,12 +197,12 @@ def parse_patents(fd,fd2):
                 for line in patent:
                     if line.startswith("WKU"):
                         patnum = re.search('WKU\s+(.*?)$',line).group(1)
-                        updnum = patnum[:8] # Remove check digit
-                        updnum = re.sub('^H0','H',updnum)
-                        updnum = re.sub('^RE0','RE',updnum)
+                        updnum = patnum[:8]  # Remove check digit
+                        updnum = re.sub('^H0',   'H', updnum)
+                        updnum = re.sub('^RE0',  'RE',updnum)
                         updnum = re.sub('^PP00?','PP',updnum)
-                        updnum = re.sub('^D0', 'D', updnum)
-                        updnum = re.sub('^T0', 'T', updnum)
+                        updnum = re.sub('^D0',   'D', updnum)
+                        updnum = re.sub('^T0',   'T', updnum)
                         if len(patnum) > 7 and patnum.startswith('0'):
                             updnum = patnum[1:8]
                         #data['patnum'] = updnum
@@ -290,7 +290,6 @@ def parse_patents(fd,fd2):
                     if invtcountry == "NULL":
                         invtcountry = 'US'
                     rawlocation[id_generator()] = [loc_idd,"NULL",invtcity,invtstate,invtcountry]
-                    
                     rawinventor[id_generator()] = [patent_id,"NULL",loc_idd,fname,lname,str(n)]
             except:
                 pass
@@ -734,4 +733,3 @@ def parse_patents(fd,fd2):
         subclassfile.writerow(v)
             
     print numii
-

--- a/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_2002_2004.py
+++ b/Scripts/Raw_Data_Parsers/uspto_parsers/generic_parser_2002_2004.py
@@ -261,12 +261,12 @@ def parse_patents(fd,fd2):
                 for line in patent:
                     if line.startswith("<B110>"):
                         patnum = re.search('<PDAT>(.*?)</PDAT>',line).group(1)
-                        updnum = re.sub('^H0','H',patnum)[:8]
-                        updnum = re.sub('^RE0','RE',updnum)[:8]
-                        updnum = re.sub('^PP0','PP',updnum)[:8]
-                        updnum = re.sub('^PP0','PP',updnum)[:8]
-                        updnum = re.sub('^D0', 'D', updnum)[:8]
-                        updnum = re.sub('^T0', 'T', updnum)[:8]
+                        updnum = patnum[:8]
+                        updnum = re.sub('^H0','H',updnum)
+                        updnum = re.sub('^RE0','RE',updnum)
+                        updnum = re.sub('^PP00?','PP',updnum)
+                        updnum = re.sub('^D0', 'D', updnum)
+                        updnum = re.sub('^T0', 'T', updnum)
                         if len(patnum) > 7 and patnum.startswith('0'):
                             updnum = patnum[1:8]
                         #print updnum


### PR DESCRIPTION
We wish to normalize patent numbers starting with H0 by removing the check digit (in position 9) and replacing the initial H0 with H. But we must remove the check digit first, because the string substitution alters the length of the string. The original code removed the check digit except when the patent number started with H0.
