### PR TITLE
Remove unused tables

### DIFF
--- a/resources/raw_db_tables_patent.json
+++ b/resources/raw_db_tables_patent.json
@@ -6,19 +6,6 @@
         "bulk_generated": false,
         "direct_load": false
       },
-      "assignee": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false,
-        "processed": true
-      },
-      "assignee_disambiguation_mapping": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
       "botanic": {
         "raw_data": true,
         "lookup": false,
@@ -42,36 +29,6 @@
         "lookup": false,
         "bulk_generated": false,
         "direct_load": true
-      },
-      "cpc_current": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "cpc_group": {
-        "raw_data": false,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "cpc_subgroup": {
-        "raw_data": false,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "cpc_subsection": {
-        "raw_data": false,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "detail_desc_length": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
       },
       "figures": {
         "raw_data": true,
@@ -104,52 +61,10 @@
         "direct_load": false,
         "tmp_view": true
       },
-      "inventor": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "inventor_disambiguation_mapping": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "inventor_gender": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
-      },
       "ipcr": {
         "raw_data": true,
         "lookup": false,
         "bulk_generated": false,
-        "direct_load": false
-      },
-      "lawyer": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "location": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "location_assignee": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "location_inventor": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
         "direct_load": false
       },
       "location_disambiguation_mapping": {
@@ -160,30 +75,6 @@
       },
       "mainclass": {
         "raw_data": true,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "mainclass_current": {
-        "raw_data": false,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "nber": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "nber_category": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
-      },
-      "nber_subcategory": {
-        "raw_data": false,
         "lookup": true,
         "bulk_generated": false,
         "direct_load": false
@@ -206,12 +97,6 @@
         "bulk_generated": false,
         "direct_load": false
       },
-      "patent_assignee": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
       "patent_contractawardnumber": {
         "raw_data": true,
         "lookup": false,
@@ -224,26 +109,8 @@
         "bulk_generated": false,
         "direct_load": true
       },
-      "patent_inventor": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": false,
-        "direct_load": false
-      },
       "pct_data": {
         "raw_data": true,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "persistent_assignee_disambig": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
-      "persistent_assignee_disambig_long": {
-        "raw_data": false,
         "lookup": false,
         "bulk_generated": true,
         "direct_load": false
@@ -290,12 +157,6 @@
         "bulk_generated": false,
         "direct_load": false
       },
-      "subclass_current": {
-        "raw_data": false,
-        "lookup": true,
-        "bulk_generated": false,
-        "direct_load": false
-      },
       "us_term_of_grant": {
         "raw_data": true,
         "lookup": false,
@@ -320,22 +181,10 @@
         "bulk_generated": false,
         "direct_load": false
       },
-      "uspc_current": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
-        "direct_load": false
-      },
       "usreldoc": {
         "raw_data": true,
         "lookup": false,
         "bulk_generated": false,
-        "direct_load": false
-      },
-      "wipo": {
-        "raw_data": false,
-        "lookup": false,
-        "bulk_generated": true,
         "direct_load": false
       },
       "wipo_field": {


### PR DESCRIPTION
Removing unused tables from the upload/patent json. These tables have been consistently empty in each of the 14 most recent upload databases.