### PR TITLE
remove lingering references to discontinued male_flag column

### DIFF
--- a/resources/table_config_bulk_exp_granted.json
+++ b/resources/table_config_bulk_exp_granted.json
@@ -1353,14 +1353,8 @@
           "category": false,
           "location_field": false
         },
-        "male_flag": {
-          "data_type": "int",
-          "null_allowed": true,
-          "category": false,
-          "location_field": false
-        },
-        "attribution_status": {
-          "data_type": "int",
+        "gender_code": {
+          "data_type": "varchar",
           "null_allowed": true,
           "category": false,
           "location_field": false

--- a/resources/table_config_bulk_exp_pgpubs.json
+++ b/resources/table_config_bulk_exp_pgpubs.json
@@ -664,14 +664,8 @@
           "category": false,
           "location_field": false
         },
-        "male_flag": {
-          "data_type": "int",
-          "null_allowed": true,
-          "category": false,
-          "location_field": false
-        },
-        "attribution_status": {
-          "data_type": "int",
+        "gender_code": {
+          "data_type": "varchar",
           "null_allowed": true,
           "category": false,
           "location_field": false

--- a/updater/post_processing/post_process_inventor.py
+++ b/updater/post_processing/post_process_inventor.py
@@ -119,8 +119,6 @@ def create_inventor(update_config):
             `id` varchar(256) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
             `name_first` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
             `name_last` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-            `male_flag` int(11) DEFAULT NULL,
-            `attribution_status` int(11) DEFAULT NULL,
             `version_indicator` date NOT NULL DEFAULT '2020-09-29',
             `created_date` timestamp NOT NULL DEFAULT current_timestamp(),
             `updated_date` timestamp NULL DEFAULT NULL ON UPDATE current_timestamp(),


### PR DESCRIPTION
addresses PV-702 
removes male_flag and attribution status columns from last export config files and quarterly inventor table in which they are unused. these are replaced in the export config files by gender_code

https://air-org.atlassian.net/browse/PV-702