### PR TITLE
add `withdrawn` to reporting and elastic patent tables

### DIFF
--- a/reporting_database_generator/02_Patent.sql
+++ b/reporting_database_generator/02_Patent.sql
@@ -268,6 +268,7 @@ create table `{{reporting_db}}`.`patent`
   `abstract` text null,
   `title` text null,
   `kind` varchar(10) null,
+  `withdrawn` tinyint(1) not null default 0,
   `num_claims` smallint unsigned null,
   `firstnamed_assignee_id` int unsigned null,
   `firstnamed_assignee_persistent_id` varchar(64) null,
@@ -305,7 +306,7 @@ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 insert into `{{reporting_db}}`.`patent`
 (
   `patent_id`, `type`, `number`, `country`, `date`, `year`,
-  `abstract`, `title`, `kind`, `num_claims`,
+  `abstract`, `title`, `kind`, `withdrawn`, `num_claims`,
   `firstnamed_assignee_id`, `firstnamed_assignee_persistent_id`,
   `firstnamed_assignee_location_id`, `firstnamed_assignee_persistent_location_id`,
   `firstnamed_assignee_city`, `firstnamed_assignee_state`,
@@ -328,7 +329,7 @@ insert into `{{reporting_db}}`.`patent`
 select
   p.`id`, case when ifnull(p.`type`, '') = 'sir' then 'statutory invention registration' else nullif(trim(p.`type`), '') end,
   `number`, nullif(trim(p.`country`), ''), tpd.`date`, year(tpd.`date`),
-  nullif(trim(p.`abstract`), ''), nullif(trim(p.`title`), ''), nullif(trim(p.`kind`), ''), p.`num_claims`,
+  nullif(trim(p.`abstract`), ''), nullif(trim(p.`title`), ''), nullif(trim(p.`kind`), ''), p.`withdrawn`, p.`num_claims`,
   tpfna.`assignee_id`, tpfna.`persistent_assignee_id`, tpfna.`location_id`,
   tpfna.`persistent_location_id`, tpfna.`city`,
   tpfna.`state`, tpfna.`country`, tpfna.`latitude`, tpfna.`longitude`,

--- a/reporting_database_generator/elastic_scripts/09_01_elastic_patents_patent.sql
+++ b/reporting_database_generator/elastic_scripts/09_01_elastic_patents_patent.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS `{{elastic_db}}`.`patents`
     `detail_desc_length`                                    int(10) unsigned DEFAULT NULL,
     `gi_statement`                                          text                                    default null,
     `patent_zero_prefix`                                    varchar(20) COLLATE utf8mb4_unicode_ci,
+    `withdrawn`                                             tinyint(1) NOT NULL DEFAULT 0
     PRIMARY KEY (`patent_id`),
     KEY                                                     `ix_patent_number` (`number`),
     KEY                                                     `ix_patent_title` (`title`(128)),
@@ -53,7 +54,7 @@ insert into `{{elastic_db}}`.patents ( patent_id, type, number, country, date, y
                                                   , uspc_current_mainclass_average_patent_processing_days
                                                   , cpc_current_group_average_patent_processing_days
                                                   , term_extension
-                                                  , detail_desc_length, gi_statement, patent_zero_prefix)
+                                                  , detail_desc_length, gi_statement, patent_zero_prefix, withdrawn)
 select p.patent_id
      , p.type
      , number
@@ -77,6 +78,7 @@ select p.patent_id
      , detail_desc_length
      , gi_statement
      , pe.patent_id_eight_char
+     , p.withdrawn
 from `{{reporting_db}}`.patent p
     left join `{{reporting_db}}`.government_interest gi
 on gi.patent_id = p.patent_id


### PR DESCRIPTION
add withdrawn field to reporting and elastic DBs to allow downstream APIs and tools to enable filtering out withdrawn data